### PR TITLE
corrected some of memory leaks

### DIFF
--- a/lfq.c
+++ b/lfq.c
@@ -183,10 +183,13 @@ qpop(Queue *queue,int thrd){
 void
 queue_free(Queue *queue){
   if (queue->head == queue->tail){
+    free(queue->head->nptr);
     free(queue->head);
     free(queue);
   } else if(queue->head != NULL && queue->tail != NULL){
+    free(queue->head->nptr);
     free(queue->head);
+    free(queue->tail->nptr);
     free(queue->tail);
     free(queue);
   }

--- a/test.c
+++ b/test.c
@@ -89,7 +89,7 @@ int main(){
 
 	sleep(1);
 
-  for (i=1; i < 90; i++){
+  for (i=0; i < 100; i++){
     Value *t = &value[i];
     free(t->data);
   }


### PR DESCRIPTION
Improved valgrind report is below 
 test 8., 109164288
==4887== Thread 2:
==4887== Invalid read of size 8
==4887==    at 0x400F71: qpop (lfq.c:126)
==4887==    by 0x400A9E: consumer (test.c:47)
==4887==    by 0x4E3F181: start_thread (pthread_create.c:312)
==4887==    by 0x514F47C: clone (clone.S:111)
==4887==  Address 0x541a040 is 0 bytes inside a block of size 16 free'd
==4887==    at 0x4C2BDEC: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4887==    by 0x401230: queue_free (lfq.c:188)
==4887==    by 0x400CE5: main (test.c:98)
==4887== 
==4887== Invalid read of size 8
==4887==    at 0x400F7C: qpop (lfq.c:127)
==4887==    by 0x400A9E: consumer (test.c:47)
==4887==    by 0x4E3F181: start_thread (pthread_create.c:312)
==4887==    by 0x514F47C: clone (clone.S:111)
==4887==  Address 0x541a048 is 8 bytes inside a block of size 16 free'd
==4887==    at 0x4C2BDEC: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4887==    by 0x401230: queue_free (lfq.c:188)
==4887==    by 0x400CE5: main (test.c:98)
==4887== 
==4887== 
==4887== HEAP SUMMARY:
==4887==     in use at exit: 64 bytes in 4 blocks
==4887==   total heap usage: 312 allocs, 308 frees, 11,888 bytes allocated
==4887== 
==4887== Thread 1:
==4887== 64 (16 direct, 48 indirect) bytes in 1 blocks are definitely lost in loss record 4 of 4
==4887==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4887==    by 0x400D60: q_initialize (lfq.c:54)
==4887==    by 0x400B48: main (test.c:67)
==4887== 
==4887== LEAK SUMMARY:
==4887==    definitely lost: 16 bytes in 1 blocks
==4887==    indirectly lost: 48 bytes in 3 blocks
==4887==      possibly lost: 0 bytes in 0 blocks
==4887==    still reachable: 0 bytes in 0 blocks
==4887==         suppressed: 0 bytes in 0 blocks
==4887== 
==4887== For counts of detected and suppressed errors, rerun with: -v
==4887== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
